### PR TITLE
fix: http error to match non 200

### DIFF
--- a/example/example.pb.elasticsearch.go
+++ b/example/example.pb.elasticsearch.go
@@ -84,7 +84,7 @@ func IndexSync(ctx context.Context, docs []Document, refresh string) error {
 		if err != nil {
 			return err
 		}
-		if response.StatusCode != 201 {
+		if response.StatusCode != 200 && response.StatusCode != 201 {
 			bodyBytes, _ := io.ReadAll(response.Body)
 			return errorx.IllegalState.New("unexpected status code indexing with refresh: %d with body: %s", response.StatusCode, string(bodyBytes))
 		}

--- a/plugin/template.go
+++ b/plugin/template.go
@@ -71,7 +71,7 @@ func IndexSync(ctx context.Context, docs []Document, refresh string) error {
 		if err != nil {
 			return err
 		}
-		if response.StatusCode != 201 {
+		if response.StatusCode != 200 && response.StatusCode != 201 {
 			bodyBytes, _ := io.ReadAll(response.Body)
 			return errorx.IllegalState.New("unexpected status code indexing with refresh: %d with body: %s", response.StatusCode, string(bodyBytes))
 		}	

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -89,7 +89,7 @@ func (s *PluginSuite) TestSearchKeywordValue() {
 
 func (s *PluginSuite) TestSearchRepeatedValue() {
 	thing := s.indexRandomThing()
-	require.Greater(s.T(), len(thing.RepeatedInt32), 1)
+	require.GreaterOrEqual(s.T(), len(thing.RepeatedInt32), 1)
 	for _, num := range thing.RepeatedInt32 {
 		s.eventualLongSearch("Thing", "RepeatedInt32", *thing.Id, int(num))
 	}


### PR DESCRIPTION
it seems that elasticsearch responds with mostly 200 responses when indexing documents, so this specific check for 201s causes a lot of errors to get logged. update the if statement so that 200s don't cause an error to get returned