### PR TITLE
fix: Change bulk indexer from pointer to non pointer. It's an interfa…

### DIFF
--- a/example/example.pb.elasticsearch.go
+++ b/example/example.pb.elasticsearch.go
@@ -40,7 +40,7 @@ const Thing2EsType = "Thing2"
 
 var ElasticsearchIndexName string
 var ElasticsearchClient *v8.Client
-var ElasticsearchBulkIndexer *esutil.BulkIndexer
+var ElasticsearchBulkIndexer esutil.BulkIndexer
 
 func GetClient() (*v8.Client, error) {
 	if ElasticsearchClient == nil {
@@ -49,22 +49,12 @@ func GetClient() (*v8.Client, error) {
 	return ElasticsearchClient, nil
 }
 
-func GetBulkIndexer() (esutil.BulkIndexer, error) {
-	if ElasticsearchBulkIndexer == nil {
-		return nil, errorx.IllegalState.New("bulk indexer has not been initialized")
-	}
-	return *ElasticsearchBulkIndexer, nil
-}
-
-func InitializeWithClients(indexName string, client *v8.Client, bulkIndexer *esutil.BulkIndexer) error {
+func InitializeWithClients(indexName string, client *v8.Client, bulkIndexer esutil.BulkIndexer) error {
 	if indexName == "" {
 		return errorx.IllegalArgument.New("An index name must be provided")
 	}
 	if client == nil {
 		return errorx.IllegalArgument.New("Client cannot be nil")
-	}
-	if bulkIndexer == nil {
-		return errorx.IllegalArgument.New("Bulk indexer cannot be nil")
 	}
 
 	ElasticsearchIndexName = indexName
@@ -97,7 +87,7 @@ func InitializeWithConfigs(indexName string, clientConfig *v8.Config, bulkIndexe
 	if err != nil {
 		errorutils.LogOnErr(nil, "error creating elasticsearch bulk indexer", err)
 	}
-	ElasticsearchBulkIndexer = &bulkIndexer
+	ElasticsearchBulkIndexer = bulkIndexer
 	return nil
 }
 
@@ -111,14 +101,7 @@ func Initialize(indexName, refresh string, addresses []string, numWorkers, flush
 		Refresh:       refresh,
 		Timeout:       timeout,
 		OnError: func(ctx context.Context, err error) {
-			errorutils.LogOnErr(nil, "error indexing item", err)
-		},
-		OnFlushStart: func(ctx context.Context) context.Context {
-			logging.Log.Info("bulk indexer starting flush")
-			return ctx
-		},
-		OnFlushEnd: func(ctx context.Context) {
-			logging.Log.Info("bulk indexer flush complete")
+			errorutils.LogOnErr(nil, "error encountered in bulk indexer", err)
 		},
 	}
 	return InitializeWithConfigs(indexName, clientConvig, bulkIndexerConfig)
@@ -253,11 +236,7 @@ func QueueBulkIndexItem(ctx context.Context, id, action string, body []byte, onS
 	if onFailure != nil {
 		item.OnFailure = onFailure
 	}
-	bulkIndexer, err := GetBulkIndexer()
-	if err != nil {
-		return err
-	}
-	err = bulkIndexer.Add(ctx, item)
+	err := ElasticsearchBulkIndexer.Add(ctx, item)
 	errorutils.LogOnErr(nil, "error adding item to bulk indexer", err)
 	return err
 }


### PR DESCRIPTION
…ce so a pointer doesn't work, you have to dereference it to use any methods which I believe is causing the issues I've seen during bulk indexing. Also removed flush and success messages because there is a lot of them and they're unnecessary. Left the default error logging.