### PR TITLE
feat: implement synchronous bulk operations

### DIFF
--- a/example/example.pb.elasticsearch.go
+++ b/example/example.pb.elasticsearch.go
@@ -589,9 +589,9 @@ func (s *Thing) DeleteWithRefresh(ctx context.Context) error {
 	return s.Delete(ctx, "wait_for")
 }
 
-type Things []*Thing
+type ThingBulkEsModel []*Thing
 
-func (s *Things) ToEsDocuments() ([]Document, error) {
+func (s *ThingBulkEsModel) ToEsDocuments() ([]Document, error) {
 	if s == nil {
 		return nil, nil
 	}
@@ -606,7 +606,7 @@ func (s *Things) ToEsDocuments() ([]Document, error) {
 	return docs, nil
 }
 
-func (s *Things) IndexAsync(ctx context.Context, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem, err error)) error {
+func (s *ThingBulkEsModel) IndexAsync(ctx context.Context, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem, err error)) error {
 	docs, err := s.ToEsDocuments()
 	if err != nil {
 		return err
@@ -614,7 +614,7 @@ func (s *Things) IndexAsync(ctx context.Context, onSuccess func(ctx context.Cont
 	return QueueDocsForIndexing(ctx, docs, onSuccess, onFailure)
 }
 
-func (s *Things) IndexSyncWithRefresh(ctx context.Context) error {
+func (s *ThingBulkEsModel) IndexSyncWithRefresh(ctx context.Context) error {
 	docs, err := s.ToEsDocuments()
 	if err != nil {
 		return err
@@ -622,7 +622,7 @@ func (s *Things) IndexSyncWithRefresh(ctx context.Context) error {
 	return BulkIndexSync(ctx, docs, "wait_for")
 }
 
-func (s *Things) IndexSync(ctx context.Context, refresh string) error {
+func (s *ThingBulkEsModel) IndexSync(ctx context.Context, refresh string) error {
 	docs, err := s.ToEsDocuments()
 	if err != nil {
 		return err
@@ -630,7 +630,7 @@ func (s *Things) IndexSync(ctx context.Context, refresh string) error {
 	return BulkIndexSync(ctx, docs, refresh)
 }
 
-func (s *Things) Delete(ctx context.Context, refresh string) error {
+func (s *ThingBulkEsModel) Delete(ctx context.Context, refresh string) error {
 	docs, err := s.ToEsDocuments()
 	if err != nil {
 		return err
@@ -642,7 +642,7 @@ func (s *Things) Delete(ctx context.Context, refresh string) error {
 	return BulkDeleteSync(ctx, ids, refresh)
 }
 
-func (s *Things) DeleteWithRefresh(ctx context.Context) error {
+func (s *ThingBulkEsModel) DeleteWithRefresh(ctx context.Context) error {
 	return s.Delete(ctx, "wait_for")
 }
 
@@ -729,9 +729,9 @@ func (s *Thing2) DeleteWithRefresh(ctx context.Context) error {
 	return s.Delete(ctx, "wait_for")
 }
 
-type Thing2s []*Thing2
+type Thing2BulkEsModel []*Thing2
 
-func (s *Thing2s) ToEsDocuments() ([]Document, error) {
+func (s *Thing2BulkEsModel) ToEsDocuments() ([]Document, error) {
 	if s == nil {
 		return nil, nil
 	}
@@ -746,7 +746,7 @@ func (s *Thing2s) ToEsDocuments() ([]Document, error) {
 	return docs, nil
 }
 
-func (s *Thing2s) IndexAsync(ctx context.Context, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem, err error)) error {
+func (s *Thing2BulkEsModel) IndexAsync(ctx context.Context, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem, err error)) error {
 	docs, err := s.ToEsDocuments()
 	if err != nil {
 		return err
@@ -754,7 +754,7 @@ func (s *Thing2s) IndexAsync(ctx context.Context, onSuccess func(ctx context.Con
 	return QueueDocsForIndexing(ctx, docs, onSuccess, onFailure)
 }
 
-func (s *Thing2s) IndexSyncWithRefresh(ctx context.Context) error {
+func (s *Thing2BulkEsModel) IndexSyncWithRefresh(ctx context.Context) error {
 	docs, err := s.ToEsDocuments()
 	if err != nil {
 		return err
@@ -762,7 +762,7 @@ func (s *Thing2s) IndexSyncWithRefresh(ctx context.Context) error {
 	return BulkIndexSync(ctx, docs, "wait_for")
 }
 
-func (s *Thing2s) IndexSync(ctx context.Context, refresh string) error {
+func (s *Thing2BulkEsModel) IndexSync(ctx context.Context, refresh string) error {
 	docs, err := s.ToEsDocuments()
 	if err != nil {
 		return err
@@ -770,7 +770,7 @@ func (s *Thing2s) IndexSync(ctx context.Context, refresh string) error {
 	return BulkIndexSync(ctx, docs, refresh)
 }
 
-func (s *Thing2s) Delete(ctx context.Context, refresh string) error {
+func (s *Thing2BulkEsModel) Delete(ctx context.Context, refresh string) error {
 	docs, err := s.ToEsDocuments()
 	if err != nil {
 		return err
@@ -782,6 +782,6 @@ func (s *Thing2s) Delete(ctx context.Context, refresh string) error {
 	return BulkDeleteSync(ctx, ids, refresh)
 }
 
-func (s *Thing2s) DeleteWithRefresh(ctx context.Context) error {
+func (s *Thing2BulkEsModel) DeleteWithRefresh(ctx context.Context) error {
 	return s.Delete(ctx, "wait_for")
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -18,9 +18,6 @@ import (
 type Builder struct {
 	plugin         *protogen.Plugin
 	messages       map[string]struct{}
-	currentFile    string
-	currentPackage string
-	dbEngine       int
 	stringEnums    bool
 	suppressWarn   bool
 }
@@ -134,25 +131,6 @@ func writeGlobalImports(f *protogen.GeneratedFile) {
 	f.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "github.com/catalystsquad/app-utils-go/logging"})
 	f.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "github.com/elastic/go-elasticsearch/v8/esutil"})
 	f.QualifiedGoIdent(protogen.GoIdent{GoImportPath: "encoding/json"})
-}
-
-var goTypeMap = map[protoreflect.Kind]string{
-	protoreflect.BoolKind:     "bool",
-	protoreflect.EnumKind:     "int",
-	protoreflect.Int32Kind:    "int32",
-	protoreflect.Sint32Kind:   "int32",
-	protoreflect.Uint32Kind:   "uint32",
-	protoreflect.Int64Kind:    "int64",
-	protoreflect.Sint64Kind:   "int64",
-	protoreflect.Uint64Kind:   "uint64",
-	protoreflect.Sfixed32Kind: "int32",
-	protoreflect.Fixed32Kind:  "uint32",
-	protoreflect.FloatKind:    "float32",
-	protoreflect.Sfixed64Kind: "int64",
-	protoreflect.Fixed64Kind:  "uint64",
-	protoreflect.DoubleKind:   "float64",
-	protoreflect.StringKind:   "string",
-	protoreflect.BytesKind:    "[]byte",
 }
 
 func getFieldOptions(field *protogen.Field) *elasticsearch.ElasticsearchFieldOptions {
@@ -285,7 +263,7 @@ func fieldValueString(field *protogen.Field) string {
 	if field.Desc.HasOptionalKeyword() {
 		return fmt.Sprintf("lo.FromPtr(%s)", name)
 	}
-	return fmt.Sprintf("%s", name)
+	return name
 }
 
 func isReference(field *protogen.Field) bool {

--- a/plugin/template.go
+++ b/plugin/template.go
@@ -460,9 +460,9 @@ func (s *{{ .Desc.Name }}) DeleteWithRefresh(ctx context.Context) error {
 	return s.Delete(ctx, "wait_for")
 }
 
-type {{ .Desc.Name }}s []*{{ .Desc.Name }}
+type {{ .Desc.Name }}BulkEsModel []*{{ .Desc.Name }}
 
-func (s *{{ .Desc.Name }}s) ToEsDocuments() ([]Document, error) {
+func (s *{{ .Desc.Name }}BulkEsModel) ToEsDocuments() ([]Document, error) {
 	if s == nil {
 		return nil, nil
 	}
@@ -477,7 +477,7 @@ func (s *{{ .Desc.Name }}s) ToEsDocuments() ([]Document, error) {
 	return docs, nil
 }
 
-func (s *{{ .Desc.Name }}s) IndexAsync(ctx context.Context, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem, err error)) error {
+func (s *{{ .Desc.Name }}BulkEsModel) IndexAsync(ctx context.Context, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem, err error)) error {
 	docs, err := s.ToEsDocuments()
 	if err != nil {
 		return err
@@ -485,7 +485,7 @@ func (s *{{ .Desc.Name }}s) IndexAsync(ctx context.Context, onSuccess func(ctx c
 	return QueueDocsForIndexing(ctx, docs, onSuccess, onFailure)
 }
 
-func (s *{{ .Desc.Name }}s) IndexSyncWithRefresh(ctx context.Context) error {
+func (s *{{ .Desc.Name }}BulkEsModel) IndexSyncWithRefresh(ctx context.Context) error {
 	docs, err := s.ToEsDocuments()
 	if err != nil {
 		return err
@@ -493,7 +493,7 @@ func (s *{{ .Desc.Name }}s) IndexSyncWithRefresh(ctx context.Context) error {
 	return BulkIndexSync(ctx, docs, "wait_for")
 }
 
-func (s *{{ .Desc.Name }}s) IndexSync(ctx context.Context, refresh string) error {
+func (s *{{ .Desc.Name }}BulkEsModel) IndexSync(ctx context.Context, refresh string) error {
 	docs, err := s.ToEsDocuments()
 	if err != nil {
 		return err
@@ -501,7 +501,7 @@ func (s *{{ .Desc.Name }}s) IndexSync(ctx context.Context, refresh string) error
 	return BulkIndexSync(ctx, docs, refresh)
 }
 
-func (s *{{ .Desc.Name }}s) Delete(ctx context.Context, refresh string) error {
+func (s *{{ .Desc.Name }}BulkEsModel) Delete(ctx context.Context, refresh string) error {
 	docs, err := s.ToEsDocuments()
 	if err != nil {
 		return err
@@ -513,7 +513,7 @@ func (s *{{ .Desc.Name }}s) Delete(ctx context.Context, refresh string) error {
 	return BulkDeleteSync(ctx, ids, refresh)
 }
 
-func (s *{{ .Desc.Name }}s) DeleteWithRefresh(ctx context.Context) error {
+func (s *{{ .Desc.Name }}BulkEsModel) DeleteWithRefresh(ctx context.Context) error {
 	return s.Delete(ctx, "wait_for")
 }
 

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -18,8 +18,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-var defaultRequestTimeout = 30 * time.Second
-
 type PluginSuite struct {
 	suite.Suite
 	container *gnomock.Container
@@ -143,7 +141,7 @@ func (s *PluginSuite) TestBulkDelete() {
 	s.eventualKeywordSearch("Thing", "Id", *thing2.Id, *thing2.Id)
 	s.eventualKeywordSearch("Thing", "Id", *thing3.Id, *thing3.Id)
 	// delete all things
-	thingsProto := example_example.Things(things)
+	thingsProto := example_example.ThingBulkEsModel(things)
 	err := thingsProto.DeleteWithRefresh(context.Background())
 	require.NoError(s.T(), err)
 	// verify that all things were deleted
@@ -408,7 +406,7 @@ func (s *PluginSuite) indexThing(thing *example_example.Thing) {
 }
 
 func (s *PluginSuite) indexThings(things []*example_example.Thing) {
-	thingsProto := example_example.Things(things)
+	thingsProto := example_example.ThingBulkEsModel(things)
 	err := thingsProto.IndexSyncWithRefresh(context.Background())
 	require.NoError(s.T(), err)
 }

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -3,6 +3,11 @@ package test
 import (
 	"context"
 	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/brianvoe/gofakeit/v6"
 	example_example "github.com/catalystsquad/protoc-gen-go-elasticsearch/example"
 	"github.com/elastic/go-elasticsearch/v8"
@@ -11,11 +16,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"io"
-	"strings"
-	"testing"
-	"time"
 )
+
+var defaultRequestTimeout = 30 * time.Second
 
 type PluginSuite struct {
 	suite.Suite
@@ -120,6 +123,36 @@ func (s *PluginSuite) TestIndexSyncWithRefresh() {
 	require.NoError(s.T(), err)
 	response := s.keywordSearch("Thing", "Id", *thing.Id)
 	require.Contains(s.T(), response, *thing.Id)
+}
+
+func (s *PluginSuite) TestBulkIndex() {
+	things := s.generateRandomThings(3)
+	s.indexThings(things)
+	// do a simple search by id to verify that all things were indexed
+	thing1, thing2, thing3 := things[0], things[1], things[2]
+	s.eventualKeywordSearch("Thing", "Id", *thing1.Id, *thing1.Id)
+	s.eventualKeywordSearch("Thing", "Id", *thing2.Id, *thing2.Id)
+	s.eventualKeywordSearch("Thing", "Id", *thing3.Id, *thing3.Id)
+}
+
+func (s *PluginSuite) TestBulkDelete() {
+	things := s.generateRandomThings(3)
+	s.indexThings(things)
+	thing1, thing2, thing3 := things[0], things[1], things[2]
+	s.eventualKeywordSearch("Thing", "Id", *thing1.Id, *thing1.Id)
+	s.eventualKeywordSearch("Thing", "Id", *thing2.Id, *thing2.Id)
+	s.eventualKeywordSearch("Thing", "Id", *thing3.Id, *thing3.Id)
+	// delete all things
+	thingsProto := example_example.Things(things)
+	err := thingsProto.DeleteWithRefresh(context.Background())
+	require.NoError(s.T(), err)
+	// verify that all things were deleted
+	response := s.keywordSearch("Thing", "Id", *thing1.Id)
+	require.NotContains(s.T(), response, *thing1.Id)
+	response = s.keywordSearch("Thing", "Id", *thing2.Id)
+	require.NotContains(s.T(), response, *thing2.Id)
+	response = s.keywordSearch("Thing", "Id", *thing3.Id)
+	require.NotContains(s.T(), response, *thing3.Id)
 }
 
 func (s *PluginSuite) startElasticsearch(t *testing.T) {
@@ -350,6 +383,18 @@ func (s *PluginSuite) generateRandomThing() *example_example.Thing {
 	return thing
 }
 
+func (s *PluginSuite) generateRandomThings(num int) []*example_example.Thing {
+	things := []*example_example.Thing{}
+	for i := 0; i < num; i++ {
+		thing := &example_example.Thing{}
+		err := gofakeit.Struct(&thing)
+		require.NoError(s.T(), err)
+		thing.ATimestamp = timestamppb.New(gofakeit.FutureDate())
+		things = append(things, thing)
+	}
+	return things
+}
+
 func (s *PluginSuite) generateRandomThing2() *example_example.Thing2 {
 	thing2 := &example_example.Thing2{}
 	err := gofakeit.Struct(&thing2)
@@ -359,6 +404,12 @@ func (s *PluginSuite) generateRandomThing2() *example_example.Thing2 {
 
 func (s *PluginSuite) indexThing(thing *example_example.Thing) {
 	err := thing.IndexSyncWithRefresh(context.Background())
+	require.NoError(s.T(), err)
+}
+
+func (s *PluginSuite) indexThings(things []*example_example.Thing) {
+	thingsProto := example_example.Things(things)
+	err := thingsProto.IndexSyncWithRefresh(context.Background())
 	require.NoError(s.T(), err)
 }
 


### PR DESCRIPTION
adds a new plural type for each search enabled object, with methods that will use a bulk indexer from the elasticsearch client

now supplies the elasticsearch client to new bulk indexers, so that client configuration is passed to the bulk indexer, which fixes a bug where the library was automatically reading from the ELASTICSEARCH_URLS environment variable.

removes some unused code