### PR TITLE
feat: refactor reindex related to use a short lived bulk indexer

### DIFF
--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -512,12 +512,12 @@ func (s *PluginSuite) indexThing2(thing2 *example_example.Thing2) {
 }
 
 func (s *PluginSuite) reindexThing2RelatedDocsAsync(thing2 *example_example.Thing2) {
-	err := thing2.ReindexRelatedDocumentsAsync(context.Background(), nil, nil)
+	err := thing2.ReindexRelatedDocumentsBulk(context.Background(), nil, nil)
 	require.NoError(s.T(), err)
 }
 
 func (s *PluginSuite) reindexThing2RelatedDocsAfterDeleteAsync(thing2 *example_example.Thing2) {
-	err := thing2.ReindexRelatedDocumentsAfterDeleteAsync(context.Background(), nil, nil)
+	err := thing2.ReindexRelatedDocumentsAfterDeleteBulk(context.Background(), nil, nil)
 	require.NoError(s.T(), err)
 }
 


### PR DESCRIPTION
this is a breaking change, as it renames the index related functions to no longer use the "async" terminology