### PR TITLE
feat: parameterize bulkIndexer in ReindexRelated methods

### DIFF
--- a/example/example.pb.elasticsearch.go
+++ b/example/example.pb.elasticsearch.go
@@ -836,7 +836,7 @@ func (s *Thing2) DeleteWithRefresh(ctx context.Context) error {
 	return s.Delete(ctx, "wait_for")
 }
 
-func (s *Thing2) ReindexRelatedDocumentsBulk(ctx context.Context, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem, err error)) error {
+func (s *Thing2) ReindexRelatedDocumentsBulk(ctx context.Context, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem, err error), bulkIndexer esutil.BulkIndexer) error {
 	nestedDocs, err := s.ToEsDocuments()
 	if err != nil {
 		return err
@@ -846,9 +846,13 @@ func (s *Thing2) ReindexRelatedDocumentsBulk(ctx context.Context, onSuccess func
 	}
 	nestedDoc := nestedDocs[0]
 
-	reqBulkIndexer, err := newRequestBulkIndexerWithRefresh("wait_for")
-	if err != nil {
-		return err
+	var createdBulkIndexer bool
+	if bulkIndexer == nil {
+		bulkIndexer, err = newRequestBulkIndexerWithRefresh("wait_for")
+		if err != nil {
+			return err
+		}
+		createdBulkIndexer = true
 	}
 
 	size := int64(100)
@@ -898,7 +902,7 @@ func (s *Thing2) ReindexRelatedDocumentsBulk(ctx context.Context, onSuccess func
 				OnSuccess:  onSuccess,
 				OnFailure:  onFailure,
 			}
-			err = reqBulkIndexer.Add(ctx, item)
+			err = bulkIndexer.Add(ctx, item)
 			if err != nil {
 				errorutils.LogOnErr(nil, "error adding item to request bulk indexer", err)
 				return err
@@ -957,7 +961,7 @@ func (s *Thing2) ReindexRelatedDocumentsBulk(ctx context.Context, onSuccess func
 				OnSuccess:  onSuccess,
 				OnFailure:  onFailure,
 			}
-			err = reqBulkIndexer.Add(ctx, item)
+			err = bulkIndexer.Add(ctx, item)
 			if err != nil {
 				errorutils.LogOnErr(nil, "error adding item to request bulk indexer", err)
 				return err
@@ -971,13 +975,25 @@ func (s *Thing2) ReindexRelatedDocumentsBulk(ctx context.Context, onSuccess func
 		searchAfter = res.Hits.Hits[len(res.Hits.Hits)-1].Sort
 	}
 
-	return reqBulkIndexer.Close(ctx)
+	if createdBulkIndexer {
+		err = bulkIndexer.Close(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
-func (s *Thing2) ReindexRelatedDocumentsAfterDeleteBulk(ctx context.Context, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem, err error)) error {
-	reqBulkIndexer, err := newRequestBulkIndexerWithRefresh("wait_for")
-	if err != nil {
-		return err
+func (s *Thing2) ReindexRelatedDocumentsAfterDeleteBulk(ctx context.Context, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem, err error), bulkIndexer esutil.BulkIndexer) error {
+	var err error
+	var createdBulkIndexer bool
+	if bulkIndexer == nil {
+		bulkIndexer, err = newRequestBulkIndexerWithRefresh("wait_for")
+		if err != nil {
+			return err
+		}
+		createdBulkIndexer = true
 	}
 
 	size := int64(100)
@@ -1016,7 +1032,7 @@ func (s *Thing2) ReindexRelatedDocumentsAfterDeleteBulk(ctx context.Context, onS
 				OnSuccess:  onSuccess,
 				OnFailure:  onFailure,
 			}
-			err = reqBulkIndexer.Add(ctx, item)
+			err = bulkIndexer.Add(ctx, item)
 			if err != nil {
 				errorutils.LogOnErr(nil, "error adding item to request bulk indexer", err)
 				return err
@@ -1064,7 +1080,7 @@ func (s *Thing2) ReindexRelatedDocumentsAfterDeleteBulk(ctx context.Context, onS
 				OnSuccess:  onSuccess,
 				OnFailure:  onFailure,
 			}
-			err = reqBulkIndexer.Add(ctx, item)
+			err = bulkIndexer.Add(ctx, item)
 			if err != nil {
 				errorutils.LogOnErr(nil, "error adding item to request bulk indexer", err)
 				return err
@@ -1078,13 +1094,25 @@ func (s *Thing2) ReindexRelatedDocumentsAfterDeleteBulk(ctx context.Context, onS
 		searchAfter = res.Hits.Hits[len(res.Hits.Hits)-1].Sort
 	}
 
-	return reqBulkIndexer.Close(ctx)
+	if createdBulkIndexer {
+		err = bulkIndexer.Close(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
-func (s *Thing2) DeleteRelatedDocumentsAsync(ctx context.Context, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem, err error)) error {
-	reqBulkIndexer, err := newRequestBulkIndexerWithRefresh("wait_for")
-	if err != nil {
-		return err
+func (s *Thing2) DeleteRelatedDocumentsBulk(ctx context.Context, onSuccess func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem), onFailure func(ctx context.Context, item esutil.BulkIndexerItem, item2 esutil.BulkIndexerResponseItem, err error), bulkIndexer esutil.BulkIndexer) error {
+	var err error
+	var createdBulkIndexer bool
+	if bulkIndexer == nil {
+		bulkIndexer, err = newRequestBulkIndexerWithRefresh("wait_for")
+		if err != nil {
+			return err
+		}
+		createdBulkIndexer = true
 	}
 
 	size := int64(100)
@@ -1109,7 +1137,7 @@ func (s *Thing2) DeleteRelatedDocumentsAsync(ctx context.Context, onSuccess func
 				OnSuccess:  onSuccess,
 				OnFailure:  onFailure,
 			}
-			err = reqBulkIndexer.Add(ctx, item)
+			err = bulkIndexer.Add(ctx, item)
 			if err != nil {
 				errorutils.LogOnErr(nil, "error adding item to request bulk indexer", err)
 				return err
@@ -1123,7 +1151,14 @@ func (s *Thing2) DeleteRelatedDocumentsAsync(ctx context.Context, onSuccess func
 		searchAfter = res.Hits.Hits[len(res.Hits.Hits)-1].Sort
 	}
 
-	return reqBulkIndexer.Close(ctx)
+	if createdBulkIndexer {
+		err = bulkIndexer.Close(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 type Thing2BulkEsModel []*Thing2

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -114,7 +114,7 @@ func (s *PluginSuite) TestReindexRelated() {
 	// update the associatedThing2 and reindex
 	oldName := associatedThing2.Name
 	associatedThing2.Name = "new name for TestReindexRelated"
-	s.reindexThing2RelatedDocsAsync(associatedThing2)
+	s.reindexThing2RelatedDocsBulk(associatedThing2)
 	// search for associated thing exact match
 	s.eventualKeywordSearch("Thing", "AssociatedThingName", associatedThing2.Name, *thing.Id)
 	// ensure that the old name is not in the index
@@ -128,7 +128,7 @@ func (s *PluginSuite) TestReindexRelatedPagination() {
 	// update the associatedThing2 and reindex
 	originalName := thing2.Name
 	thing2.Name = "new name for TestReindexRelatedPagination"
-	s.reindexThing2RelatedDocsAsync(thing2)
+	s.reindexThing2RelatedDocsBulk(thing2)
 	s.eventualSearchCount(getKeywordQuery("Thing", "AssociatedThingName", thing2.Name), count)
 	// ensure that the old name is not in the index
 	require.Equal(s.T(), 0, s.searchCount(getKeywordQuery("Thing", "AssociatedThingName", originalName)))
@@ -147,7 +147,7 @@ func (s *PluginSuite) TestReindexRelatedAfterDelete() {
 	// delete the associatedThing2 and reindex
 	err := associatedThing2.DeleteWithRefresh(context.Background())
 	require.NoError(s.T(), err)
-	s.reindexThing2RelatedDocsAfterDeleteAsync(associatedThing2)
+	s.reindexThing2RelatedDocsAfterDeleteBulk(associatedThing2)
 	// ensure that the old id is not in the index
 	s.eventualSearchCount(getKeywordQuery("Thing", "AssociatedThingId", *associatedThing2.Id), 0)
 }
@@ -511,12 +511,12 @@ func (s *PluginSuite) indexThing2(thing2 *example_example.Thing2) {
 	require.NoError(s.T(), err)
 }
 
-func (s *PluginSuite) reindexThing2RelatedDocsAsync(thing2 *example_example.Thing2) {
+func (s *PluginSuite) reindexThing2RelatedDocsBulk(thing2 *example_example.Thing2) {
 	err := thing2.ReindexRelatedDocumentsBulk(context.Background(), nil, nil)
 	require.NoError(s.T(), err)
 }
 
-func (s *PluginSuite) reindexThing2RelatedDocsAfterDeleteAsync(thing2 *example_example.Thing2) {
+func (s *PluginSuite) reindexThing2RelatedDocsAfterDeleteBulk(thing2 *example_example.Thing2) {
 	err := thing2.ReindexRelatedDocumentsAfterDeleteBulk(context.Background(), nil, nil)
 	require.NoError(s.T(), err)
 }


### PR DESCRIPTION
- feat: parameterize bulkIndexer in ReindexRelated methods

  made it so that the bulkIndexer can be passed in as a parameter or not.
  this will allow the user of the library to use the same bulk indexer
  when handling bulk related documents. this should significantly speed up
  the time to handle bulk related documents.

- fix: remove a nested for loop to improve the time complexity

- remove defer of reqBulkIndexer.Close, so that errors during closure
  are returned.
- rename test helper functions to match underlying method names

this is another breaking change. marked at a feat to bump from 0.5.0 to 0.6.0