### PR TITLE
fix: add ignore_above setting

### DIFF
--- a/example/example.pb.elasticsearch.go
+++ b/example/example.pb.elasticsearch.go
@@ -338,7 +338,7 @@ func createIndex(client *v8.Client) error {
 }
 
 func putMappings(client *v8.Client) error {
-	settings := strings.NewReader("{\"properties\":{\"id\":{\"type\":\"keyword\"},\"type\":{\"type\":\"keyword\"},\"metadata\":{\"type\":\"nested\",\"properties\":{\"key\":{\"type\":\"keyword\"},\"keywordValue\":{\"type\":\"keyword\"},\"stringValue\":{\"type\":\"text\"},\"longValue\":{\"type\":\"long\"},\"doubleValue\":{\"type\":\"double\"},\"dateValue\":{\"type\":\"date\"},\"boolValue\":{\"type\":\"boolean\"}}}}}")
+	settings := strings.NewReader("{\"properties\":{\"id\":{\"type\":\"keyword\"},\"type\":{\"type\":\"keyword\"},\"metadata\":{\"type\":\"nested\",\"properties\":{\"key\":{\"type\":\"keyword\"},\"keywordValue\":{\"type\":\"keyword\",\"ignore_above\":8191},\"stringValue\":{\"type\":\"text\"},\"longValue\":{\"type\":\"long\"},\"doubleValue\":{\"type\":\"double\"},\"dateValue\":{\"type\":\"date\"},\"boolValue\":{\"type\":\"boolean\"}}}}}")
 	req := esapi.IndicesPutMappingRequest{
 		Index: []string{ElasticsearchIndexName},
 		Body:  settings,

--- a/plugin/template.go
+++ b/plugin/template.go
@@ -325,7 +325,7 @@ func createIndex(client *v8.Client) error {
 }
 
 func putMappings(client *v8.Client) error {
-	settings := strings.NewReader("{\"properties\":{\"id\":{\"type\":\"keyword\"},\"type\":{\"type\":\"keyword\"},\"metadata\":{\"type\":\"nested\",\"properties\":{\"key\":{\"type\":\"keyword\"},\"keywordValue\":{\"type\":\"keyword\"},\"stringValue\":{\"type\":\"text\"},\"longValue\":{\"type\":\"long\"},\"doubleValue\":{\"type\":\"double\"},\"dateValue\":{\"type\":\"date\"},\"boolValue\":{\"type\":\"boolean\"}}}}}")
+	settings := strings.NewReader("{\"properties\":{\"id\":{\"type\":\"keyword\"},\"type\":{\"type\":\"keyword\"},\"metadata\":{\"type\":\"nested\",\"properties\":{\"key\":{\"type\":\"keyword\"},\"keywordValue\":{\"type\":\"keyword\",\"ignore_above\":8191},\"stringValue\":{\"type\":\"text\"},\"longValue\":{\"type\":\"long\"},\"doubleValue\":{\"type\":\"double\"},\"dateValue\":{\"type\":\"date\"},\"boolValue\":{\"type\":\"boolean\"}}}}}")
 	req := esapi.IndicesPutMappingRequest{
 		Index: []string{ElasticsearchIndexName},
 		Body:  settings,


### PR DESCRIPTION
add ignore_above setting on keywordValue field. set to 8191 bytes, to avoid lucene's byte-length limit. reference below.

- https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html

> This option is also useful for protecting against Lucene’s term
> byte-length limit of 32766.
>
> NOTE:
> The value for ignore_above is the character count, but Lucene counts
> bytes. If you use UTF-8 text with many non-ASCII characters, you may
> want to set the limit to 32766 / 4 = 8191 since UTF-8 characters may
> occupy at most 4 bytes.